### PR TITLE
remove <pre> markdown formatting

### DIFF
--- a/Source/HalflifeListener.py
+++ b/Source/HalflifeListener.py
@@ -17,7 +17,7 @@ class HalflifeListener:
 
     def on_message_handler(self, ws, message):
         for each_room in self.report_rooms:
-            each_room.send_message("    " + message)
+            each_room.send_message(message)
 
     def start(self):
         self.ws_listener.start()


### PR DESCRIPTION
Bot messages had four leading spaces added to them; remove this.