### PR TITLE
New PM alias: Halflife

### DIFF
--- a/Source/Pulse.py
+++ b/Source/Pulse.py
@@ -29,6 +29,7 @@ class Pulse:
         self._bot_header = '[ [PulseMonitor](https://github.com/Charcoal-SE/PulseMonitor) ]'
 
         bot = bp.Bot(nick, commands, rooms, [], "stackexchange.com", email, password)
+        bot.add_alias("Halflife")
 
         try:
             with open(bot._storage_prefix + 'redunda_key.txt', 'r') as file_handle:


### PR DESCRIPTION
Adds a new bot alias for PM: Halflife. 

Now, using `@Halflife` should make the bot respond, while the original name should also work. This change will require Botpy being updated to version 0.7.0. Running the new version on the bot without updating Botpy will break it.