### PR TITLE
Produce valid @displayname notifications

### DIFF
--- a/Source/Notifications.py
+++ b/Source/Notifications.py
@@ -9,6 +9,11 @@ import tabulate
 import regex as re
 
 
+def at_notification_name(username, _sub=re.compile(r"[^\w'.-]*").sub):
+    """Produce the @DisplayName notification normazilation form"""
+    return "@" + _sub('', username)
+
+
 class Notifications:
     def __init__ (self, rooms, filename='./notifications.json'):
         self.notifications = dict()
@@ -89,7 +94,7 @@ class Notifications:
                 notifications.update(self.notifications[room][regex])
         if notifications:
             return ' '.join([post] + [
-                '@{0}'.format(self.users[str(user)]) for user in notifications])
+                at_notification_name(self.users[str(user)]) for user in notifications])
         #else
         return post
 


### PR DESCRIPTION
The display name of a user is normalized to the @displayname reply form. Anything but letters, digits, underscores, single quotes, dots and dashes is removed, see https://meta.stackexchange.com/questions/51911/the-dot-in-username-within-first-3-character-preventing-from-comment-replies/51913#51913.

Fixes #23