### PR TITLE
Refactored notifications handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: Run testsuite
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Run testsuite
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        make venv
+    - name: Test with pytest
+      run: |
+        make tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build docker-push
+.PHONY: build docker-push tests
 build: docker-build.log
 docker-push: docker-build.log
 	docker push tripleee/pulsemonitor:latest
@@ -25,3 +25,11 @@ realclean: clean
 	$(RM) docker-build.log
 distclean: realclean
 	:
+
+venv:
+	python3 -m venv venv
+	venv/bin/pip install -r requirements.txt
+	venv/bin/pip install pytest pytest-cov
+
+tests: venv
+	venv/bin/pytest

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ run.prod:
 clean:
 	:
 realclean: clean
+	$(RM) -rf venv .coverage .pytest_cache
 	-image=$$(awk 'END { print $$NF }' docker-build.log) \
 	&& docker ps -q -f ancestor=$$image \
 	| xargs -r docker kill \
@@ -28,6 +29,7 @@ distclean: realclean
 
 venv:
 	python3 -m venv venv
+	venv/bin/pip install --upgrade pip
 	venv/bin/pip install -r requirements.txt
 	venv/bin/pip install pytest pytest-cov
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,20 @@ The bot has commands to add, review, and remove notifications by
 regex. Here's a quick example.
 
     you> @halflife notifications
-    Halflife> @you Active notification: someone 'foobar'
+    Halflife> | User    | Regex     |
+    Halflife> |---------+-----------|
+    Halflife> | you     | [23]/3    |
+    Halflife> | someone | (9|10)/10 |
     you> @halflife notify .*
-    Halflife> @you Added notification for you for '.*'
+    Halflife> @you Added notification for you for .*
     you> @halflife notifications
-    Halflife> @you Active notification: someone 'foobar'
-    Halflife> @you Active notification: you '.*'
+    Halflife> | User    | Regex     |
+    Halflife> |---------+-----------|
+    Halflife> | you     | [23]/3    |
+    Halflife> | someone | (9|10)/10 |
+    Halflife> | you     | .*        |
     you> @halflife unnotify .
-    Halflife> @you Removed notifications ['.*']
+    Halflife> @you Removed notifications .*
 
     you> @halflife addtag threshold [23]/3
     Halflife> @you added [tag:threshold] for regex [23]/3

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ regex. Here's a quick example.
     Halflife> | you     | [23]/3    |
     Halflife> | someone | (9|10)/10 |
     you> @halflife notify .*
-    Halflife> @you Added notification for you for `.*``
+    Halflife> @you Added notification for you for `.*`
     you> @halflife notifications
     Halflife> | User    | Regex     |
     Halflife> |---------+-----------|
@@ -50,7 +50,7 @@ regex. Here's a quick example.
     Halflife> | someone | (9|10)/10 |
     Halflife> | you     | .*        |
     you> @halflife unnotify .
-    Halflife> @you Removed notifications `.*``
+    Halflife> @you Removed notifications `.*`
 
     you> @halflife addtag threshold [23]/3
     Halflife> @you added [tag:threshold] for regex [23]/3

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ regex. Here's a quick example.
     Halflife> | you     | [23]/3    |
     Halflife> | someone | (9|10)/10 |
     you> @halflife notify .*
-    Halflife> @you Added notification for you for .*
+    Halflife> @you Added notification for you for `.*``
     you> @halflife notifications
     Halflife> | User    | Regex     |
     Halflife> |---------+-----------|
@@ -50,7 +50,7 @@ regex. Here's a quick example.
     Halflife> | someone | (9|10)/10 |
     Halflife> | you     | .*        |
     you> @halflife unnotify .
-    Halflife> @you Removed notifications .*
+    Halflife> @you Removed notifications `.*``
 
     you> @halflife addtag threshold [23]/3
     Halflife> @you added [tag:threshold] for regex [23]/3

--- a/Source/Notifications.py
+++ b/Source/Notifications.py
@@ -1,165 +1,273 @@
 import json
-import re
 import logging
+import re
+from copy import deepcopy
+from functools import wraps
+from textwrap import indent
+from threading import Lock
 
 from BotpySE import Command
 import tabulate
 
-# Our own little re wrapper library
-import regex as re
+from regex import normalize
 
 
-def at_notification_name(username, _sub=re.compile(r"[^\w'.-]*").sub):
+logger = logging.getLogger(__name__)
+
+
+def _at_notification(username, _sub=re.compile(r"[^\w'.-]*").sub):
     """Produce the @DisplayName notification normazilation form"""
-    return "@" + _sub('', username)
+    return "@" + _sub("", username)
 
 
 class Notifications:
-    def __init__ (self, rooms, filename='./notifications.json'):
-        self.notifications = dict()
+    def __init__(self, rooms, filename="./notifications.json"):
         self.filename = filename
-        self.users = dict()
+        self._lock = Lock()
         try:
-            with open(filename, 'r') as notifications_file:
-                notifications, users = json.load(notifications_file)
-            self.notifications = notifications
-            self.users = users
+            with open(filename, "r", encoding="utf8") as notifications_file:
+                self.notifications, self.users = json.load(notifications_file)
         except FileNotFoundError:
-            pass
+            self.notifications = {}
+            self.users = {}
+
         for room in rooms:
             room = str(room)
             if room not in self.notifications:
-                self.notifications[room] = dict()
+                self.notifications[room] = {}
 
-    def save (self, filename=None):
+    def _save(self, filename=None):
+        """Write out the notifications data.
+
+        Not thread-safe, when called from a thread caller is
+        expected to obtain the lock.
+
+        """
         if filename is None:
             filename = self.filename
-        with open(filename, 'w') as notifications_file:
+        with open(filename, "w", encoding="utf8") as notifications_file:
             json.dump([self.notifications, self.users], notifications_file)
 
-    def add (self, room, regex, user_id, user_name):
-        room = str(room)
-        user_id = str(user_id)
-        self.users[user_id] = user_name
-        try:
-            normalized = re.compile(regex)
-            self.notifications[room][normalized.pattern].append(user_id)
-        #except re.error: regex compilation failed
-        except KeyError:
-            self.notifications[room][regex] = [user_id]
-        self.save()
-        return {
-            'user_name': user_name,
-            'room': room,
-            'user_id': user_id,
-            'regex': normalized.pattern
-        }
+    def add(self, room, regex, user, user_name):
+        """Add the regex pattern to the room notifications for the given user
 
-    def remove(self, room, regex, user):
-        room = str(room)
-        user = str(user)
-        self.notifications[room][regex].remove(user)
-        #except ValueError:  user not in list for regex
-        #except KeyError: regex not in notifications
-        # If this was the only user with this regex, remove the regex
-        if not self.notifications[room][regex]:
-            del self.notifications[room][regex]
-        # If this was the last regex, remove the regex container, too
-        if not self.notifications[room]:
-            del self.notifications[room]
+        Returns True when the pattern wasn't yet registered for this user,
+        False otherwise.
 
-    def list(self):
-        for room in self.notifications:
-            for regex in self.notifications[room]:
-                for user in self.notifications[room][regex]:
-                    yield room, regex, user, self.users[str(user)]
+        """
+        room, user = str(room), str(user)
+        with self._lock:
+            if room not in self.notifications:
+                return False
 
-    def remove_matching(self, room, user, expr):
-        r = re.compile(expr, re.I)
-        #except re.error:
-        remove = []
-        for room_id, regex, user_id, user_name in self.list():
-            if int(room_id) != int(room):
+            regexes_for_room = self.notifications[room]
+            # make sure we have a dictionary to for users to notify when their
+            # regex matches
+            users_for_regex = regexes_for_room.setdefault(regex, [])
+
+            # only add a user if not already listed
+            if user in users_for_regex:
+                return False
+
+            users_for_regex.append(user)
+            self.users[user] = user_name
+            self._save()
+            return True
+
+    def list(self, room=None):
+        """Generate all notification entries
+
+        Entries are yielded as (room_id, regex, user_id, username) tuples
+
+        If room is not None, then the list is filtered by that room.
+
+        """
+        with self._lock:
+            # minimise locking time by creating a copy to iterate over
+            notifications = deepcopy(self.notifications)
+
+        for room_id, regexes in notifications.items():
+            if not (room is None or str(room) == room_id):
                 continue
-            if int(user_id) == int(user) and r.search(regex):
-                remove.append(regex)
-        for regex in remove:
-            self.remove(room, regex, user_id)
-        self.save()
-        return remove
+            for regex, users in regexes.items():
+                for user_id in users:
+                    yield room_id, regex, user_id, self.users[user_id]
+
+    def _remove(self, room, regex, user):
+        """Helper function for remove_matching to remove matched patterns
+
+        Not thread-safe, caller must hold lock when in a thread.
+
+        """
+        regexes_for_room = self.notifications[room]
+        users_for_regex = regexes_for_room[regex]
+
+        # users may have been added multiple times in the past, so make sure
+        # we remove them all.
+        while user in users_for_regex:
+            users_for_regex.remove(user)
+
+        if not users_for_regex:
+            # remove regex from room when there are no users left to notify
+            del regexes_for_room[regex]
+
+    def remove_matching(self, room, expr, user):
+        """Remove matching patterns
+
+        expr is treated both as the regex itself, and as regex pattern that
+        is used to search the stored patterns.
+
+        Returns a list of removed patterns.
+
+        """
+        room, user = str(room), str(user)
+        as_pattern = re.compile(expr, re.I)
+
+        to_remove = []
+
+        with self._lock:
+            regexes_for_room = self.notifications.get(room, {})
+            for regex, users_for_regex in regexes_for_room.items():
+                # check for exact match or pattern match
+                if regex == expr or as_pattern.search(regex):
+                    if user in users_for_regex:
+                        to_remove.append(regex)
+
+            # remove regexes after matching, to avoid mutating-while-iterating
+            for regex in to_remove:
+                self._remove(room, regex, user)
+
+            if to_remove:
+                self._save()
+
+        return to_remove
 
     def filter_post(self, room, post):
+        """Check a post against the patterns registered for a room"""
         room = str(room)
-        if room not in self.notifications:
-            self.notifications[room] = dict()
-        notifications = set()
-        for regex in self.notifications[room]:
+        to_notify = set()
+
+        with self._lock:
+            # minimise locking time by creating pre-processed copies
+            regexes_for_room = self.notifications.get(room, {})
+            regexes = {p: set(u) for p, u in regexes_for_room.items()}
+            at_names = {u: _at_notification(n) for u, n in self.users.items()}
+
+        for regex, users_for_regex in regexes.items():
             if re.search(regex, post):
-                notifications.update(self.notifications[room][regex])
-        if notifications:
-            return ' '.join([post] + [
-                at_notification_name(self.users[str(user)]) for user in notifications])
-        #else
-        return post
+                to_notify.update(users_for_regex)
+
+        if not to_notify:
+            return post
+
+        notifications = " ".join([at_names[user] for user in to_notify])
+        return f"{post} {notifications}"
 
 
-class CommandNotifications(Command):
+def _handle_exceptions(f):
+    """Handle any exceptions in a Command.run method, and log and report"""
+
+    @wraps(f)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return f(self, *args, **kwargs)
+        except Exception as err:
+            logger.exception(
+                f"{type(self).__name__}.{f.__name__}(*{args!r}, **{kwargs!r}) failed"
+            )
+            content = self.message.content
+            self.reply(f"Oops, the {content} command encountered a problem: {err!r}")
+
+    wrapper._handle_exceptions = True
+    return wrapper
+
+
+class NotificationsCommandBase(Command):
+    """Base class for notifications commands
+
+    Provides a notifications attribute for access to the storage instance
+    and a raw_arg property for un-processed argument access.
+
+    """
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        # auto-decorate the run method in an exception handler.
+        if not getattr(cls.run, '_handle_exceptions', False):  # pragma: no cover
+            cls.run = _handle_exceptions(cls.run)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.notifications = self.command_manager.notifications
+
+    @property
+    def raw_arg(self):
+        """Message argument as one string, with spaces and case preserved"""
+        command = self.usage()[self.usage_index].partition(' ')[0]
+        # TODO: would self.message.text_content be better here?
+        message = self.message.content
+        # remove command
+        return message.partition(command)[2].strip()
+
+
+class CommandNotifications(NotificationsCommandBase):
     @staticmethod
     def usage():
         return ["notifications"]
 
     def run(self):
-        logging.info("NOTIFICATIONS")
-        notifications = [[x[3], x[1]] for x in \
-                self.command_manager.notifications.list()]
-        table = tabulate.tabulate(
-            notifications, headers=["User", "Regex"], tablefmt="orgtbl")
-        self.post('    ' + re.sub('\n', '\n    ', table), False)
+        room = str(self.message.room.id)
+        logger.info(f"NOTIFICATIONS by {self.message.user.id} in {room}")
+        entries = [[user, pat] for _, pat, _, user in self.notifications.list(room)]
+        table = tabulate.tabulate(entries, headers=["User", "Regex"], tablefmt="orgtbl")
+        self.post(indent(table, "    "), False)
 
 
-class CommandNotify(Command):
+class CommandNotify(NotificationsCommandBase):
     @staticmethod
     def usage():
-        return ["notify ..."]
+        return ["notify * ..."]
 
     def run(self):
         room = self.message.room.id
         user_id = self.message.user.id
         user_name = self.message.user.name
-        regex = ' '.join(self.arguments)
-        logging.info("NOTIFY {0} for {1}".format(user_id, user_name, regex))
+        # Take pattern from original message to preserve case and spacing
+        # then normalize (remove residual <code>...</code> HTML formatting)
+        pattern = normalize(self.raw_arg)
+        logger.info(f"NOTIFY {user_id} in {room} for {pattern}")
         try:
-            notification = self.command_manager.notifications.add(
-                room, regex, user_id, user_name)
-            self.reply(
-                'Added notification for {0} for {1}'.format(
-                    notification['user_name'], notification['regex']))
+            re.compile(pattern)
         except re.error as err:
-            self.reply('Could not add notification {0}: {1}'.format(
-                regex, err))
+            self.reply(f"Could not add notification {pattern}: {err}")
+            return
+
+        if self.notifications.add(room, pattern, user_id, user_name):
+            self.reply(f"Added notification for {user_name} for {pattern}")
+        else:
+            self.reply(f"Pattern {pattern} already registered for {user_name}")
 
 
-class CommandUnnotify(Command):
+class CommandUnnotify(NotificationsCommandBase):
     @staticmethod
     def usage():
-        return ["unnotify ..."]
+        return ["unnotify * ..."]
 
     def run(self):
         room = self.message.room.id
-        user = self.message.user.id
-        pat = ' '.join(self.arguments)
-        logging.info("UNNOTIFY {0} for {1}".format(pat, self.message.user.name))
-        removed = []
+        user_id = self.message.user.id
+        user_name = self.message.user.name
+        # Take pattern from original message to preserve case and spacing
+        # then normalize (remove residual <code>...</code> HTML formatting)
+        pattern = normalize(self.raw_arg)
+        logger.info(f"UNNOTIFY {pattern} for {user_id} in {room}")
         try:
-            removed = self.command_manager.notifications.remove_matching(
-                room, user, pat)
+            re.compile(pattern)
         except re.error as err:
-            self.reply('Could not remove {0}: {1}'.format(pat, err))
-            return False
-        except ValueError as err:
-            self.reply('Could not remove {0!r}: {1}'.format((room, user, pat), err))
-            return False
-        if not removed:
-            self.reply('No matches on {0}'.format(pat))
-            return False
-        self.reply('Removed notifications {0!r}'.format(removed))
+            self.reply(f"Could not remove notification {pattern}: {err}")
+            return
+
+        removed = self.notifications.remove_matching(room, pattern, user_id)
+        if removed:
+            self.reply(f"Removed notifications: {', '.join(removed)}")
+        else:
+            self.reply(f"No matches on {pattern} for {user_name}")

--- a/Source/Notifications.py
+++ b/Source/Notifications.py
@@ -43,7 +43,7 @@ class Notifications:
         expected to obtain the lock.
 
         """
-        if filename is None:
+        if filename is None:  # pragma: no cover
             filename = self.filename
         with open(filename, "w", encoding="utf8") as notifications_file:
             json.dump([self.notifications, self.users], notifications_file)

--- a/Source/conftest.py
+++ b/Source/conftest.py
@@ -1,0 +1,2 @@
+# empty on purpose, here to mark this as a source
+# directory for pytest

--- a/Source/regex.py
+++ b/Source/regex.py
@@ -4,10 +4,10 @@ from html import unescape
 
 _re_compile = compile
 
-def _normalize(regex):
+def normalize(regex):
     if regex.startswith('<code>') and regex.endswith('</code>'):
         regex = regex[6:-7]
     return unescape(regex)
 
 def compile(regex, flags=0):
-    return _re_compile(_normalize(regex), flags)
+    return _re_compile(normalize(regex), flags)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = --cov=Source --cov-config=pytest.ini --cov-report term-missing
+testpaths = Source tests
 
 [run]
 branch = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+addopts = --cov=Source --cov-config=pytest.ini --cov-report term-missing
+
+[run]
+branch = true
+
+[report]
+precision = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+from contextlib import nullcontext
+from unittest import mock
+
+
+def pytest_addoption(parser, pluginmanager):
+    parser.addoption(
+        "--disable-notification-locking",
+        dest="testthreading_disable_locking",
+        action="store_true",
+        default=False,
+        help="Neuter the lock used in Notifications to help the threading tests fail",
+    )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    ctx = nullcontext()
+    if (
+        item.config.option.testthreading_disable_locking
+        and isinstance(item, pytest.Function)
+        and item.parent.nodeid == "tests/test_notifications.py::TestThreading"
+    ):
+        # make failure all but certain by replacing the lock with a no-op.
+        ctx = mock.patch("Notifications.Lock", nullcontext)
+
+    with ctx:
+        _ = yield

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,370 @@
+import json
+import logging
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+class _NotificationsTestsBase:
+    @pytest.fixture(autouse=True)
+    def setup_notifications(self, tmp_path, caplog):
+        """Fixtures for notifications tests
+
+        - Provide Notifications instance self.notifications with temporary file
+          location (available as self.filepath)
+
+        - Capture Notifications.py logging in self.logs
+
+        """
+        self.filepath = tmp_path / "notifications.json"
+        self.create_notifications()
+
+        self.logs = caplog
+        self.logs.set_level(logging.INFO, logger="Notifications")
+
+    def create_notifications(self):
+        from Notifications import Notifications
+
+        self.notifications = Notifications([17, 42], self.filepath)
+
+    @property
+    def saved_notifications(self):
+        try:
+            return json.loads(self.filepath.read_text())[0]
+        except FileNotFoundError:
+            return None
+
+    @property
+    def saved_users(self):
+        try:
+            return json.loads(self.filepath.read_text())[1]
+        except FileNotFoundError:
+            return None
+
+
+class TestNotifications(_NotificationsTestsBase):
+    def test_list_empty(self):
+        assert list(self.notifications.list()) == []
+        assert list(self.notifications.list(42)) == []
+        assert list(self.notifications.list(-1)) == []
+
+    def test_list_all(self):
+        notifications = self.notifications
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+        notifications.add(42, r"Monty (Python|Hall)", 23, "Terry Gilliam")
+
+        assert sorted(notifications.list()) == [
+            ("17", "foo .* bar", "13", "Graham Chapman"),
+            ("42", "Monty (Python|Hall)", "23", "Terry Gilliam"),
+        ]
+
+    def test_list_filtered(self):
+        notifications = self.notifications
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+        notifications.add(42, r"Monty (Python|Hall)", 23, "Terry Gilliam")
+
+        assert list(notifications.list(17)) == [
+            ("17", "foo .* bar", "13", "Graham Chapman")
+        ]
+        assert list(notifications.list(42)) == [
+            ("42", "Monty (Python|Hall)", "23", "Terry Gilliam"),
+        ]
+        assert list(notifications.list(9999)) == []
+
+    def test_add(self):
+        notifications = self.notifications
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+        notifications.add(42, r"Monty (Python|Hall)", 23, "Terry Gilliam")
+
+        assert self.saved_notifications == {
+            "17": {"foo .* bar": ["13"]},
+            "42": {"Monty (Python|Hall)": ["23"]},
+        }
+        assert self.saved_users == {"13": "Graham Chapman", "23": "Terry Gilliam"}
+
+    def test_add_nonexistent(self):
+        notifications = self.notifications
+        notifications.add(9999, r"foo .* bar", 13, "Graham Chapman")
+
+        # nothing changed, nothing saved
+        assert self.saved_notifications is None
+
+    def test_add_shared_pattern(self):
+        notifications = self.notifications
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+        notifications.add(17, r"foo .* bar", 23, "Terry Gilliam")
+
+        assert self.saved_notifications == {
+            "17": {"foo .* bar": ["13", "23"]},
+            "42": {},
+        }
+        assert self.saved_users == {"13": "Graham Chapman", "23": "Terry Gilliam"}
+
+    def test_add_repeated(self):
+        notifications = self.notifications
+        assert notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+        assert not notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+
+        assert self.saved_notifications == {
+            "17": {"foo .* bar": ["13"]},
+            "42": {},
+        }
+        assert self.saved_users == {"13": "Graham Chapman"}
+
+    def test_remove_empty(self):
+        notifications = self.notifications
+        assert notifications.remove_matching(17, r".*", 13) == []
+        assert notifications.remove_matching(999, r".*", 13) == []
+
+    def test_remove_wrong_room(self):
+        notifications = self.notifications
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+
+        assert notifications.remove_matching(42, r".*", 13) == []
+        assert self.saved_notifications == {
+            "17": {"foo .* bar": ["13"]},
+            "42": {},
+        }
+
+    def test_remove_shared_pattern(self):
+        notifications = self.notifications
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+        notifications.add(17, r"foo .* bar", 23, "Terry Gilliam")
+        notifications.add(17, r"foo spam bar", 23, "Terry Gilliam")
+
+        assert notifications.remove_matching(17, r".*", 13) == ["foo .* bar"]
+        assert self.saved_notifications == {
+            "17": {"foo .* bar": ["23"], "foo spam bar": ["23"]},
+            "42": {},
+        }
+
+    def test_remove_exact_match(self):
+        notifications = self.notifications
+        notifications.add(17, r"Monty (Python|Hall)", 13, "Graham Chapman")
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+
+        assert notifications.remove_matching(17, r"Monty (Python|Hall)", 13) == [
+            "Monty (Python|Hall)"
+        ]
+        assert self.saved_notifications == {
+            "17": {"foo .* bar": ["13"]},
+            "42": {},
+        }
+
+    def test_remove_multiple(self):
+        notifications = self.notifications
+        notifications.add(17, r"Monty (Python|Hall)", 13, "Graham Chapman")
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+        notifications.add(17, r"(PYTHON|RUBY)", 13, "Graham Chapman")
+
+        assert sorted(notifications.remove_matching(17, r"python", 13)) == [
+            "(PYTHON|RUBY)",
+            "Monty (Python|Hall)",
+        ]
+
+    def test_remove_duplicate_user_only(self):
+        # list the same user more than once for a pattern
+        # one of two variants: with no other users there
+        with self.filepath.open("w", encoding="utf8") as f:
+            json.dump(
+                [{"17": {"pattern": ["13", "13", "13"]}}, {"13": "Graham Chapman"},], f,
+            )
+        self.create_notifications()
+        notifications = self.notifications
+        notifications.remove_matching(17, r"pattern", 13) == ["pattern"]
+
+        assert self.saved_notifications == {"17": {}, "42": {}}
+
+    def test_remove_duplicate_user_shared(self):
+        # list the same user more than once for a pattern
+        # one of two variants: with another user there
+        with self.filepath.open("w", encoding="utf8") as f:
+            json.dump(
+                [
+                    {"17": {"pattern": ["13", "23", "13", "13"]}},
+                    {"13": "Graham Chapman", "23": "Terry Gilliam"},
+                ],
+                f,
+            )
+        self.create_notifications()
+        notifications = self.notifications
+        notifications.remove_matching(17, r"pattern", 13) == ["pattern"]
+
+        assert self.saved_notifications == {"17": {"pattern": ["23"]}, "42": {}}
+
+    def test_filter_empty(self):
+        notifications = self.notifications
+
+        post = "Lorum ipsum dolor"
+        assert notifications.filter_post(17, post) == post
+        assert notifications.filter_post(42, post) == post
+        assert notifications.filter_post(999, post) == post
+
+    def test_filter_post_room(self):
+        notifications = self.notifications
+        notifications.add(17, r"[Ll]\w+ ipsum", 13, "Graham Chapman")
+        notifications.add(17, r".*", 83, "Terry Gilliam")
+        notifications.add(17, r"Knights of .*", 97, "John Cleese")
+        notifications.add(42, r".*", 31, "Eric Idle")
+        notifications.add(42, r"Lorum .*", 23, "Michael Palin")
+
+        post = "Lorum ipsum dolor"
+        msg = notifications.filter_post(17, post)
+        assert msg.startswith(post)
+        assert sorted(msg[len(post) :].split()) == ["@GrahamChapman", "@TerryGilliam"]
+        msg = notifications.filter_post(42, post)
+        assert msg.startswith(post)
+        assert sorted(msg[len(post) :].split()) == ["@EricIdle", "@MichaelPalin"]
+
+
+class TestCommands(_NotificationsTestsBase):
+    def dispatch(self, content, room=17, user_id=13, user_name="Graham Chapman"):
+        """Simulate BotpySE's command handling for tests"""
+        from Notifications import CommandNotify, CommandNotifications, CommandUnnotify
+
+        commands = {
+            c.usage()[0].split(None, 1)[0]: c
+            for c in (CommandNotify, CommandNotifications, CommandUnnotify)
+        }
+
+        # BotpySE lowercases messages when building the argument list
+        cmd, *arguments = content.lower().split()
+
+        # mock out a command manager, user, room and message object
+        command_manager = mock.Mock(notifications=self.notifications)
+        user = mock.Mock(id=user_id)
+        user.configure_mock(name=user_name)  # can't set name any other way
+        message = mock.Mock(user=user, room=mock.Mock(id=room), content=content)
+
+        # capture responses sent via Command.post and Command.reply
+        output = SimpleNamespace(reply=[], post=[])
+        message.message.reply.side_effect = lambda t, **k: output.reply.append(t)
+        message.room.send_message.side_effect = lambda t, **k: output.post.append(t)
+
+        commands[cmd](command_manager, message, arguments).run()
+
+        return output
+
+    def test_notifications_empty(self):
+        response = "    | User   | Regex   |\n    |--------+---------|"
+        assert self.dispatch("notifications").post == [response]
+        assert self.dispatch("notifications", room=42).post == [response]
+
+    def test_list_filtered(self):
+        notifications = self.notifications
+        notifications.add(17, r"foo .* bar", 13, "Graham Chapman")
+        notifications.add(42, r"Monty (Python|Hall)", 23, "Terry Gilliam")
+
+        output = self.dispatch("notifications")
+        assert output.post[0].splitlines()[2:] == [
+            "    | Graham Chapman | foo .* bar |"
+        ]
+
+    def test_notify_case_sensitive(self):
+        pat = "pat  with  spacing and UPPERCASE"
+        output = self.dispatch(f"notify {pat}")
+        assert output.reply == [f"Added notification for Graham Chapman for {pat}"]
+        assert self.saved_notifications == {"17": {pat: ["13"]}, "42": {}}
+
+    def test_notify_invalid_pattern(self):
+        pat = "(pat incomplete"
+        output = self.dispatch(f"notify {pat}")
+        assert output.reply == [
+            f"Could not add notification {pat}: "
+            "missing ), unterminated subpattern at position 0"
+        ]
+
+    def test_notify_existing(self):
+        pat = ".*"
+        self.notifications.add(17, pat, 13, "Graham Chapman")
+        output = self.dispatch(f"notify {pat}")
+        assert output.reply == [f"Pattern {pat} already registered for Graham Chapman"]
+
+    def test_notify_normalised(self):
+        pat = "Euro: \u20AC"
+        pat_html = "<code>Euro: &euro;</code>"
+        output = self.dispatch(f"notify {pat_html}")
+        assert output.reply == [f"Added notification for Graham Chapman for {pat}"]
+
+        output = self.dispatch(f"notify {pat}")
+        assert output.reply == [f"Pattern {pat} already registered for Graham Chapman"]
+
+        output = self.dispatch(f"notify {pat_html}")
+        assert output.reply == [f"Pattern {pat} already registered for Graham Chapman"]
+
+        output = self.dispatch("notify <code>(</code>")
+        assert output.reply == [
+            "Could not add notification (: "
+            "missing ), unterminated subpattern at position 0"
+        ]
+
+    def test_unnotify_missing(self):
+        pat = "foo .* bar"
+        output = self.dispatch(f"unnotify {pat}")
+        assert output.reply == [f"No matches on {pat} for Graham Chapman"]
+
+    def test_unnotify_invalid_pattern(self):
+        pat = "(pat incomplete"
+        output = self.dispatch(f"unnotify {pat}")
+        assert output.reply == [
+            f"Could not remove notification {pat}: "
+            "missing ), unterminated subpattern at position 0"
+        ]
+
+    def test_unnotify_case_sensitivity(self):
+        # this pattern would not match itself, so would only match as literal text
+        pat1 = r"^pat \w with  spacing and UPPERCASE"
+        # this pattern is going to be matched with a case-insensitive general search
+        pat2 = r"foo .* BAR"
+        self.notifications.add(17, pat1, 13, "Graham Chapman")
+        self.notifications.add(17, pat2, 13, "Graham Chapman")
+
+        output = self.dispatch(f"unnotify {pat1}")
+        assert output.reply == [f"Removed notifications: {pat1}"]
+
+        output = self.dispatch(f"unnotify ^foo.*bar$")
+        assert output.reply == [f"Removed notifications: {pat2}"]
+
+    def test_unnotify_normalised(self):
+        pat = "Euro: \u20AC"
+        self.notifications.add(17, pat, 13, "Graham Chapman")
+
+        pat_html = "<code>Euro: &euro;</code>"
+        output = self.dispatch(f"unnotify {pat_html}")
+        assert output.reply == [f"Removed notifications: {pat}"]
+
+        output = self.dispatch(f"unnotify {pat_html}")
+        assert output.reply == [f"No matches on {pat} for Graham Chapman"]
+
+        output = self.dispatch("unnotify <code>(</code>")
+        assert output.reply == [
+            "Could not remove notification (: "
+            "missing ), unterminated subpattern at position 0"
+        ]
+
+    def test_command_logging(self):
+        self.dispatch("notifications", room=42, user_id=19)
+        self.dispatch("notify ^\\w+", room=17, user_id=23)
+        self.dispatch("unnotify ^\\w+", room=81, user_id=31)
+        assert self.logs.record_tuples == [
+            ("Notifications", logging.INFO, "NOTIFICATIONS by 19 in 42"),
+            ("Notifications", logging.INFO, "NOTIFY 23 in 17 for ^\\w+"),
+            ("Notifications", logging.INFO, "UNNOTIFY ^\\w+ for 31 in 81"),
+        ]
+
+    @mock.patch("Notifications.Notifications.add")
+    def test_exception(self, add_mock):
+        """Introduce an exception in notifications.add and verify it is handled"""
+        exc = ValueError("mocked exception")
+        add_mock.side_effect = exc
+        command = "notify foo .* bar"
+        output = self.dispatch(command)
+        assert output.reply == [
+            f"Oops, the {command} command encountered a problem: {exc!r}"
+        ]
+
+        assert [r.levelno for r in self.logs.records] == [logging.INFO, logging.ERROR]
+        assert self.logs.records[1].msg == "CommandNotify.run(*(), **{}) failed"
+        assert self.logs.records[1].exc_info[:2] == (type(exc), exc)
+

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -507,6 +507,10 @@ class TestThreading(_CommandsTestsBase):
             _wait_for(threads, 3)
             pytest.fail("Threads didn't complete", False)
 
+        # any issues with errors will have been reported by the thread runner
+        # so no need to report twice.
+        self.logs.clear()
+
         if not exception_queue.empty():
             lines = ["One or more messages triggered an exception:\n"]
             while not exception_queue.empty():
@@ -517,7 +521,6 @@ class TestThreading(_CommandsTestsBase):
 
             pytest.fail("".join(lines), False)
 
-        self.logs.clear()
         patterns = [p[7:] for p in messages if p != "notifications"]
         assert {
             rid: {p: sorted(users) for p, users in pat.items()}

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -270,14 +270,14 @@ class TestCommands(_CommandsTestsBase):
     def test_notify_case_sensitive(self):
         pat = "pat  with  spacing and UPPERCASE"
         output = self.dispatch(f"notify {pat}")
-        assert output.reply == [f"Added notification for Graham Chapman for {pat}"]
+        assert output.reply == [f"Added notification for Graham Chapman for `{pat}`"]
         assert self.saved_notifications == {"17": {pat: ["13"]}, "42": {}}
 
     def test_notify_invalid_pattern(self):
         pat = "(pat incomplete"
         output = self.dispatch(f"notify {pat}")
         assert output.reply == [
-            f"Could not add notification {pat}: "
+            f"Could not add notification `{pat}`: "
             "missing ), unterminated subpattern at position 0"
         ]
 
@@ -285,36 +285,42 @@ class TestCommands(_CommandsTestsBase):
         pat = ".*"
         self.notifications.add(17, pat, 13, "Graham Chapman")
         output = self.dispatch(f"notify {pat}")
-        assert output.reply == [f"Pattern {pat} already registered for Graham Chapman"]
+        assert output.reply == [
+            f"Pattern `{pat}` already registered for Graham Chapman"
+        ]
 
     def test_notify_normalised(self):
         pat = "Euro: \u20AC"
         pat_html = "<code>Euro: &euro;</code>"
         output = self.dispatch(f"notify {pat_html}")
-        assert output.reply == [f"Added notification for Graham Chapman for {pat}"]
+        assert output.reply == [f"Added notification for Graham Chapman for `{pat}`"]
 
         output = self.dispatch(f"notify {pat}")
-        assert output.reply == [f"Pattern {pat} already registered for Graham Chapman"]
+        assert output.reply == [
+            f"Pattern `{pat}` already registered for Graham Chapman"
+        ]
 
         output = self.dispatch(f"notify {pat_html}")
-        assert output.reply == [f"Pattern {pat} already registered for Graham Chapman"]
+        assert output.reply == [
+            f"Pattern `{pat}` already registered for Graham Chapman"
+        ]
 
         output = self.dispatch("notify <code>(</code>")
         assert output.reply == [
-            "Could not add notification (: "
+            "Could not add notification `(`: "
             "missing ), unterminated subpattern at position 0"
         ]
 
     def test_unnotify_missing(self):
         pat = "foo .* bar"
         output = self.dispatch(f"unnotify {pat}")
-        assert output.reply == [f"No matches on {pat} for Graham Chapman"]
+        assert output.reply == [f"No matches on `{pat}` for Graham Chapman"]
 
     def test_unnotify_invalid_pattern(self):
         pat = "(pat incomplete"
         output = self.dispatch(f"unnotify {pat}")
         assert output.reply == [
-            f"Could not remove notification {pat}: "
+            f"Could not remove notification `{pat}`: "
             "missing ), unterminated subpattern at position 0"
         ]
 
@@ -327,10 +333,10 @@ class TestCommands(_CommandsTestsBase):
         self.notifications.add(17, pat2, 13, "Graham Chapman")
 
         output = self.dispatch(f"unnotify {pat1}")
-        assert output.reply == [f"Removed notifications: {pat1}"]
+        assert output.reply == [f"Removed notifications: `{pat1}`"]
 
         output = self.dispatch(f"unnotify ^foo.*bar$")
-        assert output.reply == [f"Removed notifications: {pat2}"]
+        assert output.reply == [f"Removed notifications: `{pat2}`"]
 
     def test_unnotify_normalised(self):
         pat = "Euro: \u20AC"
@@ -338,14 +344,14 @@ class TestCommands(_CommandsTestsBase):
 
         pat_html = "<code>Euro: &euro;</code>"
         output = self.dispatch(f"unnotify {pat_html}")
-        assert output.reply == [f"Removed notifications: {pat}"]
+        assert output.reply == [f"Removed notifications: `{pat}`"]
 
         output = self.dispatch(f"unnotify {pat_html}")
-        assert output.reply == [f"No matches on {pat} for Graham Chapman"]
+        assert output.reply == [f"No matches on `{pat}` for Graham Chapman"]
 
         output = self.dispatch("unnotify <code>(</code>")
         assert output.reply == [
-            "Could not remove notification (: "
+            "Could not remove notification `(`: "
             "missing ), unterminated subpattern at position 0"
         ]
 


### PR DESCRIPTION
This is rather a big refactor of the notifications storage and commands, to

- eliminate bugs with pattern removing
- ensuring thread-safety (there was none)
- improved unnotify handling (patterns are matched both on equality and on regex matching)

I've included a test suite to help keep this part in working order.